### PR TITLE
changed user_choice menu book_repository.py

### DIFF
--- a/book_repository.py
+++ b/book_repository.py
@@ -413,13 +413,14 @@ def search_books():
 def user_action():  
     # Option 5. Exit was chosen oven 0. exit in case users confuse 0 with O
     while True:    
-        user_choice = input("\nChoose one of the following options:"
+        # Menu text changed for user to know that they should enter only the number to select an option
+        user_choice = input("\nYou can choose one of the following options:"
                             "\n\t 1. Enter a new book in the repository"
                             "\n\t 2. Update the information of a book in the repository"
                             "\n\t 3. Delete a book from the repository"
                             "\n\t 4. Search for a book in repository"
                             "\n\t 5. Exit the program."
-                            "\nWhat do you want to do? "
+                            "\n Please, enter the number of the option you want to choose: "
                             )
         # if-elif statement to provide the actions for each of the user's choices
         # If the user choses <1. Enter a new book in the repository>        


### PR DESCRIPTION
The text in the user_choice menu options was not specific about the user needing to enter only the number to indicate their choice, and not enter the text. This could lead to erroneous user entries and errors. The text was changed for the user to know that they only need to enter a digit to choose an option from the menu. 